### PR TITLE
Change "About" tab behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,16 +34,25 @@
 
         <!-- Navigation Tabs -->
         <ul class="nav nav-tabs">
-            <li class="active"><a data-toggle="tab" href="#preconfigured">Preconfigured Templates</a></li>
+            <li class="active"><a data-toggle="tab" href="#about">About</a></li>
+            <li><a data-toggle="tab" href="#preconfigured">Preconfigured Templates</a></li>
             <li><a data-toggle="tab" href="#api-resources">API Resources</a></li>
             <li><a data-toggle="tab" href="#lookup-resources">Lookup Resources</a></li>
             <li><a data-toggle="tab" href="#extensions">Extensions</a></li>
             <li><a data-toggle="tab" href="#artifact-collection">Artifact Collection</a></li>
-            <li><a data-toggle="tab" href="#about">About</a></li>
         </ul>
 
         <form id="yamlForm">
             <div class="tab-content">
+                <!-- About Tab -->
+                <div id="about" class="tab-pane fade in active">
+                    <fieldset>
+                        <legend>About</legend>
+                        <div id="about-content">
+                            <!-- README.md content will be injected here -->
+                        </div>
+                    </fieldset>
+                </div>
                 <!-- Preconfigured Templates Tab -->
                 <!-- How to contribute a template
                     To add a new Preconfigured Template:
@@ -57,7 +66,7 @@
                             b. Do the required add-ons get enabled on their corresponding tabs?
                             c. etc.
                 -->
-                <div id="preconfigured" class="tab-pane fade in active">
+                <div id="preconfigured" class="tab-pane fade">
                     <fieldset>
                         <legend>Preconfigured Templates</legend>
                         <div>
@@ -512,18 +521,8 @@
                         </fieldset>
                     </fieldset>
                 </div>
-                <!-- About Tab -->
-                <div id="about" class="tab-pane fade">
-                    <fieldset>
-                        <legend>About</legend>
-                        <div id="about-content">
-                            <!-- README.md content will be injected here -->
-                        </div>
-                    </fieldset>
-                </div>
-
                 <!-- YAML Output Block -->
-                <div class="template-boundary">
+                <div id="yamlOutputSection" class="template-boundary">
                     <h2>Infrastructure-as-Code Template:</h2>
                     <div class="button-container">
                         <button type="button" onclick="resetForm()">Reset Template</button>

--- a/js/script.js
+++ b/js/script.js
@@ -482,13 +482,6 @@ function initializeListeners() {
             });
         });
     });
-
-    // about page
-    $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-        if (e.target.hash === '#about') {
-            loadReadme();
-        }
-    });
 }
 function resetForm() {
     document.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
@@ -596,4 +589,21 @@ document.addEventListener('DOMContentLoaded', () => {
     initializeListeners();
     Prism.highlightAll();
     generateYAML();
+
+    // Check if the 'About' tab is active and load the content
+    const aboutTab = document.querySelector('li.active a[href="#about"]');
+    if (aboutTab) {
+        loadReadme();
+        document.getElementById('yamlOutputSection').style.display = 'none'; // Hide YAML Output Block
+    }
+
+    // Add event listener for tab changes to show/hide the YAML Output Block
+    $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+        if (e.target.hash === '#about') {
+            loadReadme();
+            document.getElementById('yamlOutputSection').style.display = 'none'; // Hide YAML Output Block
+        } else {
+            document.getElementById('yamlOutputSection').style.display = 'block'; // Show YAML Output Block
+        }
+    });
 });

--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,5 @@
 // app versioning
-const version = '1.0.0';
+const version = '1.0.1';
 
 // begin yaml generation
 let currentYAMLState = {}; // Store the current state of the YAML

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@ The LimaCharlie Infrastructure-as-Code (IaC) Generator allows users to select va
 For more information on how to apply IaC configurations to an LC org, read about the infrastructure extension [here](https://docs.limacharlie.io/docs/extensions-lc-extensions-infrastructure).
 
 App URL: https://iac.limacharlie.io/
+
 Repo URL: https://github.com/refractionPOINT/lc-iac-generator/
 
 ### Disclaimer / Important Considerations


### PR DESCRIPTION
## Description of the change

Reordered tabs to put About first, and set it to be default on page load. Also, removed rendering of YAML output block on the About tab. Iterated patch version due to noticeable UI change. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
