### PR TITLE
Update auto-tag-systems.yaml

### DIFF
--- a/templates/auto-tag-systems.yaml
+++ b/templates/auto-tag-systems.yaml
@@ -24,6 +24,7 @@ hives:
                     events:
                         - NEW_PROCESS
                         - EXISTING_PROCESS
+                        - NETWORK_CONNECTIONS
                     op: contains
                     path: event/FILE_PATH
                     value: 'Microsoft.ActiveDirectory.WebServices.exe'


### PR DESCRIPTION

## Description of the change

Adding NETWORK_CONNECTIONS will end up tagging the Domain Controllers quicker, otherwise it can take a long time for the Process events to occur.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fix refractionPOINT/tracking#1
