### PR TITLE
Update auto-tag-systems.yaml

### DIFF
--- a/templates/auto-tag-systems.yaml
+++ b/templates/auto-tag-systems.yaml
@@ -9,7 +9,8 @@ hives:
                         - EXISTING_PROCESS
                     op: matches
                     path: event/FILE_PATH
-                    re: (apache|httpd|nginx|lighttpd|tomcat|java|w3wp|iisexpress|php-fpm|gunicorn|uwsgi)
+                    case sensitive: false
+                    re: (apache|httpd|nginx|lighttpd|tomcat|nodejs|w3wp|iisexpress|php-fpm|gunicorn|uwsgi)
                 respond:
                     - action: add tag
                       tag: webserver


### PR DESCRIPTION
## Description of the change

- Removed "java" as it's too broad and catches Java applications that are used on workstations.
- Added NodeJS
- Added case insensitive to cover Linux and Windows use of the paths with those names. As an example, Windows uses `Apache` Linux uses `apache`


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fix refractionPOINT/tracking#1
