### PR TITLE
Fixing binlib and payload-manager names.

### DIFF
--- a/index.html
+++ b/index.html
@@ -637,7 +637,7 @@
                             </label><br>
                             
                             <label title="BinLib Extension" data-content="BinLib (Binary Library) is the collection of data and metadata pertaining to executable binaries, such as EXE or ELF files, that have been observed within your organization." data-toggle="popover" data-trigger="hover" data-placement="bottom">
-                                <input type="checkbox" id="ext-binlib" name="extensions" value="ext-binlib"> BinLib
+                                <input type="checkbox" id="binlib" name="extensions" value="binlib"> BinLib
                             </label><br>
                             
                             <label title="Cloud CLI Extension" data-content="The Cloud CLI extension allows you to trigger actions within other tools such as AWS, GCP, and DigitalOcean based on events generated in LimaCharlie." data-toggle="popover" data-trigger="hover" data-placement="bottom">
@@ -707,7 +707,7 @@
                             </label><br>
                             
                             <label title="Payload Manager Extension" data-content="The Payloads Manager extension allows you to create, maintain & automatically refresh payloads in the organization to then deploy them on endpoints via Windows, Mac, or Linux sensors." data-toggle="popover" data-trigger="hover" data-placement="bottom">
-                                <input type="checkbox" id="ext-payload-manager" name="extensions" value="ext-payload-manager"> Payload Manager
+                                <input type="checkbox" id="payload-manager" name="extensions" value="payload-manager"> Payload Manager
                             </label><br>
                             
                             <label title="Plaso Extension" data-content="The Plaso extension allows you to run Plaso against forensic artifacts collected from endpoints based on D&R rule actions." data-toggle="popover" data-trigger="hover" data-placement="bottom">


### PR DESCRIPTION
## Description of the change

> Fixed naming for payload-manager and binlib in IaC generator. These extensions did not follow the standard 'ext-' prefix convention, causing generated code to break when selected.

## Type of change
- [ X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fix refractionPOINT/tracking#1
