### PR TITLE
Remove SnapAttack

### DIFF
--- a/index.html
+++ b/index.html
@@ -765,10 +765,6 @@
                                     <input type="checkbox" id="ext-sigma" name="extensions" value="ext-sigma"> Sigma
                                 </label><br>
 
-                                <label title="SnapAttack Extension" data-content="Access the latest SnapAttack Community Rules." data-toggle="popover" data-trigger="hover" data-placement="bottom">
-                                    <input type="checkbox" id="ext-snapattack" name="extensions" value="ext-snapattack"> SnapAttack
-                                </label><br>
-
                                 <label title="Soteria Rules AWS" data-content="Managed set of Detection & Response rules for AWS developed by Soteria." data-toggle="popover" data-trigger="hover" data-placement="bottom">
                                     <input type="checkbox" id="soteria-rules-aws" name="extensions" value="soteria-rules-aws"> Soteria Rules AWS
                                 </label><br>


### PR DESCRIPTION
SnapAttack got bought and they deprecated their community rules.
